### PR TITLE
Fixed final spec to pass in the grade number

### DIFF
--- a/spec/student_spec.rb
+++ b/spec/student_spec.rb
@@ -182,7 +182,7 @@ describe Student do
         jess.grade = 10
         jess.save
 
-        tenth_grade = Student.all_students_in_grade_X
+        tenth_grade = Student.all_students_in_grade_X(10)
         expect(tenth_grade.size).to eq(3)
       end
     end


### PR DESCRIPTION
Right now the last spec says:
'returns an array of all students in a given grade X'

But the spec code calls:
        tenth_grade = Student.all_students_in_grade_X

Adding the parameter in that call to pass in grade 10
        tenth_grade = Student.all_students_in_grade_X(10)

This is based on error @ShiLi007 was having with the lab. Tested and working with solution code but would appreciate :eyes: from @pletcher before I :ship: it!
